### PR TITLE
.error and .load was deprecated in jQuery 3.0

### DIFF
--- a/src/jvectormap.js
+++ b/src/jvectormap.js
@@ -99,9 +99,9 @@ var jvm = {
     var deferred = new jvm.$.Deferred(),
         img = jvm.$('<img/>');
 
-    img.error(function(){
+    img.on('error', function(){
       deferred.reject();
-    }).load(function(){
+    }).on('load', function(){
       deferred.resolve(img);
     });
     img.attr('src', url);


### PR DESCRIPTION
This commit is taken from the base repository. It is needed because in package.json the version of jquery is not limited to <3.
Please bump package version after merge.

https://api.jquery.com/error/ - deprecated and removed
https://api.jquery.com/load/ - was replaced, not handling event anymore
See: https://github.com/bjornd/jvectormap/commit/b260e6f27afbea00d027d6cbd56ccb08d3f47ec9